### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Component which presents a dismissible view from the bottom of the screen
 
-[![Cocoapods Compatible](http://img.shields.io/cocoapods/v/Bottomsheet.svg?style=flat)](http://cocoadocs.org/docsets/Bottomsheet)
+[![CocoaPods Compatible](http://img.shields.io/cocoapods/v/Bottomsheet.svg?style=flat)](http://cocoadocs.org/docsets/Bottomsheet)
 [![Swift 2.0](https://img.shields.io/badge/Swift-2.0-orange.svg?style=flat)](https://developer.apple.com/swift/)
 
 <img src="https://github.com/hryk224/Bottomsheet/wiki/images/sample1.gif" width="320" > <img src="https://github.com/hryk224/Bottomsheet/wiki/images/sample2.gif" width="320" > <img src="https://github.com/hryk224/Bottomsheet/wiki/images/sample3.gif" width="320" > <img src="https://github.com/hryk224/Bottomsheet/wiki/images/sample4.gif" width="320" >
@@ -14,7 +14,7 @@ Component which presents a dismissible view from the bottom of the screen
 
 ## install
 
-#### Cocoapods
+#### CocoaPods
 
 Adding the following to your `Podfile` and running `pod install`:
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
